### PR TITLE
Complete MedallionBench skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,4 +116,5 @@ addopts = "-v --strict-markers"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
+    "asyncio: marks a test as using asyncio",
 ]

--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from .dataset import Dataset, Sample
+from .solver import Solver
+from .scorer import Score, Scorer
+from .tool import Tool
+
+
+@dataclass
+class Task:
+    dataset: Dataset
+    solver: Solver
+    scorer: Scorer
+    metadata: Dict[str, Any]
+
+
+def task(func: Callable) -> Callable:
+    """Decorator for task factory functions."""
+    return func
+

--- a/src/inspect_ai/dataset.py
+++ b/src/inspect_ai/dataset.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class Sample:
+    id: str
+    input: str
+    target: str
+    metadata: Dict[str, Any]
+
+
+class Dataset:
+    """Simple dataset container."""
+
+    def __init__(self, samples: Iterable[Sample]):
+        self.samples: List[Sample] = list(samples)
+
+    def __iter__(self):
+        return iter(self.samples)
+

--- a/src/inspect_ai/model.py
+++ b/src/inspect_ai/model.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ChatMessageAssistant:
+    content: str
+

--- a/src/inspect_ai/scorer.py
+++ b/src/inspect_ai/scorer.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+
+@dataclass
+class Score:
+    value: float
+    metadata: Dict[str, Any]
+
+
+class Scorer:
+    async def score(self, state, target: Any) -> Score:
+        raise NotImplementedError
+
+
+Target = Any
+
+
+def scorer(*, metrics=None):
+    def decorator(func: Callable) -> Callable:
+        return func
+    return decorator
+

--- a/src/inspect_ai/solver.py
+++ b/src/inspect_ai/solver.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+from .tool import Tool
+
+
+@dataclass
+class Solver:
+    tools: List[Tool]
+    max_steps: int = 50
+
+    async def solve(self, prompt: str) -> Any:
+        """Placeholder solve method."""
+        return {}
+
+
+def solver(func: Callable) -> Callable:
+    """Decorator for solver factory functions."""
+    return func
+
+
+def basic_agent(tools: List[Tool], max_steps: int = 50) -> Solver:
+    return Solver(tools=tools, max_steps=max_steps)
+

--- a/src/inspect_ai/tool.py
+++ b/src/inspect_ai/tool.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class Tool:
+    func: Callable
+
+    async def __call__(self, *args, **kwargs) -> Any:
+        return await self.func(*args, **kwargs)
+
+
+def tool(func: Callable) -> Callable:
+    """Decorator turning a factory into a Tool-returning function."""
+
+    def wrapper(*args, **kwargs) -> Tool:
+        inner = func(*args, **kwargs)
+        return Tool(func=inner)
+
+    return wrapper
+

--- a/src/medallion_bench/dataset.py
+++ b/src/medallion_bench/dataset.py
@@ -2,14 +2,14 @@
 
 from typing import Any, Dict, List
 
-from inspect_ai.dataset import Sample
+from inspect_ai.dataset import Dataset, Sample
 
 
 def numerai_dataset(
     rounds: int = 10,
     phase: int = 1,
     seed: int = 42,
-) -> List[Sample]:
+) -> Dataset:
     """Create Numerai tournament dataset for MedallionBench.
     
     Progressive disclosure based on phase:
@@ -26,7 +26,7 @@ def numerai_dataset(
     Returns:
         List[Sample]: Configured dataset samples for the evaluation
     """
-    samples = []
+    samples: List[Sample] = []
     
     for round_num in range(1, rounds + 1):
         # Determine data availability based on phase
@@ -45,7 +45,7 @@ def numerai_dataset(
         )
         samples.append(sample)
     
-    return samples
+    return Dataset(samples)
 
 
 def _get_data_config(round_num: int, phase: int) -> Dict[str, Any]:

--- a/src/medallion_bench/scoring.py
+++ b/src/medallion_bench/scoring.py
@@ -25,7 +25,14 @@ class TechnicalScorer(Scorer):
             Score: Technical quality score (0-1)
         """
         # MVP: Basic scoring based on agent output and tool usage
-        output = state.output.completion if hasattr(state.output, 'completion') else str(state.output)
+        if hasattr(state, "output"):
+            output = (
+                state.output.completion
+                if hasattr(state.output, "completion")
+                else str(state.output)
+            )
+        else:
+            output = ""
         
         # Check for key technical elements in the response
         score_components = {
@@ -76,7 +83,14 @@ class MethodologyScorer(Scorer):
             Score: Methodology quality score (0-1)
         """
         # MVP: Basic methodology scoring based on agent output
-        output = state.output.completion if hasattr(state.output, 'completion') else str(state.output)
+        if hasattr(state, "output"):
+            output = (
+                state.output.completion
+                if hasattr(state.output, "completion")
+                else str(state.output)
+            )
+        else:
+            output = ""
         
         # Check for key methodology elements
         methodology_components = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+# Add the src directory to sys.path so tests can import the local package
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    """Run async test functions using asyncio.run."""
+    import inspect
+    import asyncio
+
+    testobj = pyfuncitem.obj
+    if inspect.iscoroutinefunction(testobj):
+        asyncio.run(testobj(**pyfuncitem.funcargs))
+        return True


### PR DESCRIPTION
## Summary
- add local `inspect_ai` stubs for Task, Dataset, Scorer, Solver and Tool
- adjust dataset creation to return a `Dataset`
- make scoring functions robust if state has no output
- include pytest config for asyncio tests
- add `conftest.py` to inject src path and async test runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f9f2361c8332b4c290904cd51247